### PR TITLE
Fix security warning by upgrading Django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==2.1.2
+django==2.1.5
 Pillow==5.3.0
 psycopg2==2.7.5
 pytest==3.8.2


### PR DESCRIPTION
There are some security fixes github has been warning about.
This is only a simple Django patch upgrade.